### PR TITLE
Fix environment to use main branch of PUDL

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,14 +5,14 @@ channels:
 dependencies:
   # Packages required for setting up the environment
   - pip>=21,<23
-  - python>=3.8,<3.11
+  - python>=3.10,<3.12
   - setuptools<62
 
   # Packages specified in setup.py that need or benefit from binary conda packages
   - geopandas>=0.11,<0.12
   - pygeos>=0.11,<0.13 # Python wrappers for the GEOS spatial libraries
   # Visualization and data validation packages used interactively but not required.
-  - plotly==5.11.0
+  - plotly<=5.11
   # - python-snappy>=0.6,<0.7  # Supports snappy compression in pyarrow/parquet
 
   # Packages not specified in setup.py that provide optional, helpful binaries:

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - geopandas>=0.11,<0.12
   - pygeos>=0.11,<0.13 # Python wrappers for the GEOS spatial libraries
   # Visualization and data validation packages used interactively but not required.
-  - plotly<=5.11
+  - plotly>=5.11,<5.12
   # - python-snappy>=0.6,<0.7  # Supports snappy compression in pyarrow/parquet
 
   # Packages not specified in setup.py that provide optional, helpful binaries:

--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,13 @@ setup(
     license="MIT",
     # Fill in search keywords that users might use to find the package
     keywords=[],
-    python_requires=">=3.8,<3.11",
+    python_requires=">=3.10,<3.12",
     # In order for the dependabot to update versions, they must be listed here.
     # Use the format pkg_name>=x,<y", Included packages are just examples:
     install_requires=[
         "pandas>=1.4,<1.5.3",
         "sqlalchemy>=1.4,<1.4.46",
-        "catalystcoop-pudl @ git+https://github.com/catalyst-cooperative/pudl@dev",
+        "catalystcoop-pudl @ git+https://github.com/catalyst-cooperative/pudl@main",
     ],
     extras_require={
         "dev": [
@@ -66,7 +66,6 @@ setup(
             "mccabe>=0.6,<0.8",  # Checks that code isn't overly complicated
             "mypy>=0.942,<0.992",  # Static type checking
             "pep8-naming>=0.12,<0.14",  # Require PEP8 compliant variable names
-            "plotly==5.11.0",  # Used for visualizations
             "pre-commit>=2.9,<2.21",  # Allow us to run pre-commit hooks in testing
             "pydocstyle>=5.1,<6.2",  # Style guidelines for Python documentation
             "pytest>=6.2,<7.3",  # Our testing framework


### PR DESCRIPTION
The PUDL `dev` branch has a conflicting dependency with `awscli` that is going to get fixed. For now, switching this environment to pull from `main`. 

^ this got fixed