### PR TITLE
Fix openpyxl issue reading excel files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "beautifulsoup4>=4.11,<4.12",
         "catalystcoop-pudl @ git+https://github.com/catalyst-cooperative/pudl@dev",
         "geopandas>=0.11,<0.13",
+        "openpyxl==3.1.0",
         "pandas>=1.4,<1.5.4",
         "plotly>=5.11,<5.14",
         "pygeos>=0.11,<0.15",


### PR DESCRIPTION
Version 3.1.1 of `openpyxl`, which is a dependency for `pandas` broke `pd.read_excel`. See [this issue](https://foss.heptapod.net/openpyxl/openpyxl/-/issues/1963). The bug has been addressed and fixed with [this commit](https://foss.heptapod.net/openpyxl/openpyxl/-/commit/18e48210100ca073a89d1115271d7ff1f0c6109a) but I'm pinning `openpyxl` to `3.1.0` until there is a release of `openpyxl` with the bug fix. 

This PR just pins openpyxl to 3.1.0.