### PR TITLE
Dependency version fix for openpyxl and sqalchemy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,12 @@ setup(
         "beautifulsoup4>=4.11,<4.12",
         "catalystcoop-pudl @ git+https://github.com/catalyst-cooperative/pudl@dev",
         "geopandas>=0.11,<0.13",
-        "openpyxl==3.1.0",
+        "openpyxl>=3,!=3.1.1,<4",
         "pandas>=1.4,<1.5.4",
         "plotly>=5.11,<5.14",
         "pygeos>=0.11,<0.15",
         "Shapely>1.8.0,<2.1",
-        "sqlalchemy>=1.4,<2.0.5",
+        "sqlalchemy>=1.4,<2.0.0",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "plotly>=5.11,<5.14",
         "pygeos>=0.11,<0.15",
         "Shapely>1.8.0,<2.1",
-        "sqlalchemy>=1.4,<2.0.0",
+        "sqlalchemy>=1.4,<2",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Making the versions so `openpyxl` will never be version `3.1.1` and `sqalchemy<2` until `pandas 2.0` comes out.