### PR TITLE
Revert "Update pandas requirement from <2,>=1.5 to >=1.5,<3"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "catalystcoop-pudl @ git+https://github.com/catalyst-cooperative/pudl@dev",
     "geopandas>=0.11,<0.13",
     "openpyxl>=3,!=3.1.1,<4",
-    "pandas>=1.5,<3",
+    "pandas>=1.5,<2",
     "plotly>=5.11,<5.15",
     "pygeos>=0.11,<0.15",
     "Shapely>1.8.0,<2.1",


### PR DESCRIPTION
Reverts catalyst-cooperative/rmi-energy-communities#117

PUDL isn't compatible with pandas 2.0 yet.