### PR TITLE
Revert "Update sqlalchemy requirement from <2,>=1.4 to >=1.4,<3"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "plotly>=5.11,<5.15",
     "pygeos>=0.11,<0.15",
     "Shapely>1.8.0,<2.1",
-    "sqlalchemy>=1.4,<3",
+    "sqlalchemy>=1.4,<2",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Reverts catalyst-cooperative/rmi-energy-communities#118

sqlalchemy 2.0 is not compatible with pandas 1.5